### PR TITLE
Dev/fix template system

### DIFF
--- a/modules/pages/__main__.py
+++ b/modules/pages/__main__.py
@@ -1,4 +1,5 @@
-from functools import wraps
+import inspect
+
 import ez
 
 from .dbi import PAGE_REPOSITORY, PageInfoModel
@@ -13,12 +14,37 @@ def make_page_route(page: PageInfoModel):
     if not page.slug.startswith("/"):
         page.slug = f"/{page.slug}"
 
-    render = ez.templates.get(page.template_name).render
+    template = ez.templates.get(page.template_name)
+    signature = inspect.signature(template.render)
+    inject_kwargs = {}
+    parameters = []
+    for param in signature.parameters.values():
+        annotation = param.annotation
+        if annotation is inspect.Parameter.empty:
+            continue
+        if isinstance(annotation, type) and issubclass(annotation, ez.templates.PageData):
+            if param.kind in { param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY }:
+                inject_kwargs[param.name] = ez.templates.PageData(
+                    id=page.id,
+                    title=page.title,
+                    content=page.content,
+                    slug=page.slug,
+                    template_name=page.template_name
+                )
+            elif param.kind == param.POSITIONAL_ONLY:
+                raise ValueError("Page parameter may not be positional-only")
+            else:
+                raise ValueError(f"Invalid parameter kind for page: {param.kind}")
+        else:
+            parameters.append(param)
 
-    @wraps(render)
+    new_signature = signature.replace(parameters=parameters)
+
     def page_route(*args, **kwargs):
-        return render(*args, **kwargs)
+        return template.render(*args, **inject_kwargs, **kwargs)
     
+    page_route.__signature__ = new_signature
+
     ez.get(page.slug)(page_route)
 
 

--- a/modules/pages/__main__.py
+++ b/modules/pages/__main__.py
@@ -21,8 +21,8 @@ def make_page_route(page: PageInfoModel):
     for param in signature.parameters.values():
         annotation = param.annotation
         if annotation is inspect.Parameter.empty:
-            continue
-        if isinstance(annotation, type) and issubclass(annotation, ez.templates.PageData):
+            parameters.append(param)
+        elif isinstance(annotation, type) and issubclass(annotation, ez.templates.PageData):
             if param.kind in { param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY }:
                 inject_kwargs[param.name] = ez.templates.PageData(
                     id=page.id,

--- a/modules/pages/dbi.py
+++ b/modules/pages/dbi.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String
 
 from data.database import DatabaseModel, DatabaseRepository
 

--- a/modules/templates/builtins/loader.py
+++ b/modules/templates/builtins/loader.py
@@ -3,12 +3,13 @@ import yaml
 from pathlib import Path
 from importlib.util import spec_from_file_location, module_from_spec
 
+from .template_module import TemplateModule
+from .template_module_loader import TemplateModuleLoader
+from .ez_template import EZTemplate
+
 from ..template_pack import TemplatePack
 from ..template_package_info import TemplatePackageInfo, TemplateMappingInfo
 from ..machinery.loader import ITemplatePackLoader, TemplatePackage
-
-from .ez_template import EZTemplate
-from .template_module_loader import TemplateModuleLoader
 
 
 def create_mapping(info: TemplateMappingInfo, path: Path) -> dict[Path, str]:

--- a/modules/templates/builtins/template_module.py
+++ b/modules/templates/builtins/template_module.py
@@ -7,8 +7,9 @@ from ..types import RenderResult
 class TemplateModule(ModuleType):
     render: Callable[..., RenderResult] | None
 
-    def __init__(self, name: str, doc: str | None = ...) -> None:
+    def __init__(self, name: str, doc: str | None = "") -> None:
         super().__init__(name, doc)
+        self.render = None
 
     def __str__(self) -> str:
         return f"<TemplateModule {self.__name__}>"

--- a/modules/templates/ez_templates/__init__.py
+++ b/modules/templates/ez_templates/__init__.py
@@ -1,3 +1,5 @@
+from .page_data import PageData
+
 from ..errors import TemplateNotFoundError
 from ..manager import TEMPLATE_MANAGER as __tm
 from ..template_package import TemplatePackage

--- a/modules/templates/ez_templates/page_data.py
+++ b/modules/templates/ez_templates/page_data.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PageData:
+    id: int
+    title: str
+    content: str
+    slug: str
+    template_name: str

--- a/modules/templates/template.py
+++ b/modules/templates/template.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from typing import Callable, TypeVar, ParamSpec, Generic, overload, TYPE_CHECKING
 
 from .types import RenderResult
@@ -63,13 +64,14 @@ def template(name: str):
                 raise TypeError(
                     f"Class '{cls.__name__}' must implement a 'render' method to be a valid template."
                 )
-
+            
             class _(Template):
                 def __init__(self):
                     super().__init__(name, None)
 
+                @wraps(cls.render)
                 def render(self, *args, **kwargs) -> RenderResult:
-                    return cls(*args, **kwargs).render()
+                    return cls.render(cls(), *args, **kwargs)
 
             current_pack.add(type(cls.__name__, (_,), {})())
             return cls

--- a/modules/templates/template.py
+++ b/modules/templates/template.py
@@ -34,8 +34,9 @@ class Template(TemplateBase):
 
 
 class FunctionalTemplate(Template, Generic[P, RenderResultT]):
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, render: Callable[P, RenderResultT]) -> None:
         super().__init__(name, None)
+        self.render = render
 
     def __call__(self, *args: P.args, **kwds: P.kwargs) -> RenderResultT:
         return self.render(*args, **kwds)
@@ -78,11 +79,7 @@ def template(name: str):
 
         elif is_function(cls):
 
-            class _(FunctionalTemplate[P]):
-                def render(self, *args: P.args, **kwargs: P.kwargs) -> RenderResult:
-                    return cls(*args, **kwargs)
-
-            result = type(name, (_,), {})(name)
+            result = type(name, (FunctionalTemplate,), {})(name, cls)
             current_pack.add(result)
             return result
         else:

--- a/modules/templates/template.py
+++ b/modules/templates/template.py
@@ -46,7 +46,7 @@ def template(name: str):
     current_pack = _try_get_current_pack()
     if current_pack is None:
         raise TypeError(
-            f"Current template pack loader does not support adding templates (current loader: {TEMPLATE_MANAGER.current_loader})"
+            f"Current template pack loader does not support adding templates."
         )
 
     @overload


### PR DESCRIPTION
I have fixed the page data injection code and it now allows adding more parameters which will be handled by FastAPI.

In the case where the `render` function omits the page parameter, the page data will not be passed.

The page data parameter(s) can be identifies via annotation, as page data parameter(s) are declared using the `PageData` 
type annotation that may be imported from `ez.templates`.

```py
from jsx.html import Div

from ez.templates import template, PageData

@template("page1")
def page1(my_page: PageData, query_param: str):
  return Div(
    my_page.id, my_page.title, my_page.content, my_page.slug
  )
  
@template("page2")
def page2(query_param: str):
  return Div(
    "This template does not support page data. Data is fetched separately."
  )
```

If the template slug contains a path parameter - such as `/product/{product_id}` - it can be accessed by having
a parameter with the same name (in the example, a parameter named `product_id`).